### PR TITLE
Feature-179-Sprint-view-optIn-changes

### DIFF
--- a/src/functions/severa/get-filtered-workhours/handler.ts
+++ b/src/functions/severa/get-filtered-workhours/handler.ts
@@ -26,10 +26,12 @@ export const getWorkHoursHandler: APIGatewayProxyHandler = async (event) => {
     } else {
       if (severaUserId) {
         if (!optInUserGuids.has(severaUserId)) {
-          allWorkHours = [];
-        } else {
-          allWorkHours = await api.getWorkHoursForUser(severaUserId, startDate, endDate);
+          return {
+            statusCode: 404,
+            body: JSON.stringify({ error: "User not found or not opted-in" }),
+          };
         }
+        allWorkHours = await api.getWorkHoursForUser(severaUserId, startDate, endDate);
       } else {
         throw new Error("severaUserId is required when severaProjectId is not specified");
       }

--- a/src/functions/severa/get-filtered-workhours/handler.ts
+++ b/src/functions/severa/get-filtered-workhours/handler.ts
@@ -19,6 +19,7 @@ export const getWorkHoursHandler: APIGatewayProxyHandler = async (event) => {
     const optInUsers = await api.getOptInUsers();
     const optInUserGuids = new Set(optInUsers.map((u) => u.guid));
 
+    let errors: Array<{ userGuid: string, error: any }> = [];
     // If severaProjectId is specified and severaUserId is not, make requests for each opted-in user
     let allWorkHours: SeveraResponseWorkHours[] = [];
     if (severaProjectId) {
@@ -33,7 +34,7 @@ export const getWorkHoursHandler: APIGatewayProxyHandler = async (event) => {
             const userWorkHours = await api.getWorkHours(url);
             return userWorkHours;
           } catch (e) {
-            // If there is an error for a single user, just skip
+            errors.push({ userGuid: user.guid, error: e });
             return [];
           }
         })

--- a/src/functions/severa/get-filtered-workhours/handler.ts
+++ b/src/functions/severa/get-filtered-workhours/handler.ts
@@ -30,12 +30,23 @@ export const getWorkHoursHandler: APIGatewayProxyHandler = async (event) => {
      *
      * @returns {string} - The constructed custom URL for fetching work hours.
      */
-    const buildWorkHoursUrl = (severaProjectId?: string, severaUserId?: string, startDate?: string, endDate?: string) => {
+    const buildWorkHoursUrl = async (severaProjectId?: string, severaUserId?: string, startDate?: string, endDate?: string) => {
       let endpointPath: string;
+      try {
+      await api.getKeywordIdForUser(severaUserId, "isSeveraOptIn");
+    } catch {
+      return {
+        statusCode: 403,
+        body: JSON.stringify({ message: "User has not opted in." }),
+      };
+    }
 
       if (severaProjectId) {
         endpointPath = `projects/${severaProjectId}/workhours`;
       } else if (severaUserId) {
+      if (severaUserId && !optInUserGuids.has(severaUserId)) {
+        throw new Error("User has not opted in.");
+      }
         endpointPath = `users/${severaUserId}/workhours`;
       } else {
         endpointPath = "workhours";
@@ -49,7 +60,11 @@ export const getWorkHoursHandler: APIGatewayProxyHandler = async (event) => {
       return customUrl;
     };
 
-    const url = buildWorkHoursUrl(severaProjectId, severaUserId, startDate, endDate);
+    const url = await buildWorkHoursUrl(severaProjectId, severaUserId, startDate, endDate);
+    if (!(url instanceof URL)) {
+      // url is an error response object, return it directly
+      return url;
+    }
     const response = await api.getWorkHours(url);
 
     // Filtering by opted in users only

--- a/src/functions/severa/get-filtered-workhours/handler.ts
+++ b/src/functions/severa/get-filtered-workhours/handler.ts
@@ -11,7 +11,7 @@ import type SeveraResponseWorkHours from "src/types/severa/workHour/severaRespon
  * @param event - API Gateway event containing the userId, projectId, and phaseId.
  */
 export const getWorkHoursHandler: APIGatewayProxyHandler = async (event) => {
-  const { startTime: startTime, endTime: endTime, severaProjectId, severaPhaseId, severaUserId } = event.queryStringParameters || {};
+  const { startDate: startDate, endDate: endDate, severaProjectId, severaPhaseId, severaUserId } = event.queryStringParameters || {};
 
   try {
     const api = CreateSeveraApiService();
@@ -30,8 +30,8 @@ export const getWorkHoursHandler: APIGatewayProxyHandler = async (event) => {
             const url = new URL(`${process.env.SEVERA_DEMO_BASE_URL}/v1/users/${user.guid}/workhours`);
             // This endpoint/query parameter is working but it is not documented proper in Severa API spec
             url.searchParams.append("projectGuid", severaProjectId);
-            if (startTime) url.searchParams.append("startDate", startTime);
-            if (endTime) url.searchParams.append("endDate", endTime);
+            if (startDate) url.searchParams.append("startDate", startDate);
+            if (endDate) url.searchParams.append("endDate", endDate);
             const userWorkHours = await api.getWorkHours(url);
             return userWorkHours;
           } catch (e) {
@@ -55,8 +55,8 @@ export const getWorkHoursHandler: APIGatewayProxyHandler = async (event) => {
       } else {
         throw new Error("severaUserId is required when severaProjectId is not specified");
       }
-      if (startTime) url.searchParams.append("startTime", startTime);
-      if (endTime) url.searchParams.append("endTime", endTime);
+      if (startDate) url.searchParams.append("startDate", startDate);
+      if (endDate) url.searchParams.append("endDate", endDate);
 
       allWorkHours = await api.getWorkHours(url);
     }

--- a/src/functions/severa/get-filtered-workhours/handler.ts
+++ b/src/functions/severa/get-filtered-workhours/handler.ts
@@ -11,7 +11,7 @@ import type SeveraResponseWorkHours from "src/types/severa/workHour/severaRespon
  * @param event - API Gateway event containing the userId, projectId, and phaseId.
  */
 export const getWorkHoursHandler: APIGatewayProxyHandler = async (event) => {
-  const { startDate, endDate, severaProjectId, severaPhaseId, severaUserId } = event.queryStringParameters || {};
+  const { startTime: startTime, endTime: endTime, severaProjectId, severaPhaseId, severaUserId } = event.queryStringParameters || {};
 
   try {
     const api = CreateSeveraApiService();
@@ -30,8 +30,8 @@ export const getWorkHoursHandler: APIGatewayProxyHandler = async (event) => {
             const url = new URL(`${process.env.SEVERA_DEMO_BASE_URL}/v1/users/${user.guid}/workhours`);
             // This endpoint/query parameter is working but it is not documented proper in Severa API spec
             url.searchParams.append("projectGuid", severaProjectId);
-            if (startDate) url.searchParams.append("startDate", startDate);
-            if (endDate) url.searchParams.append("endDate", endDate);
+            if (startTime) url.searchParams.append("startDate", startTime);
+            if (endTime) url.searchParams.append("endDate", endTime);
             const userWorkHours = await api.getWorkHours(url);
             return userWorkHours;
           } catch (e) {
@@ -53,11 +53,10 @@ export const getWorkHoursHandler: APIGatewayProxyHandler = async (event) => {
       if (severaUserId) {
         url = new URL(`${process.env.SEVERA_DEMO_BASE_URL}/v1/users/${severaUserId}/workhours`);
       } else {
-      // Absolute endpoint, fetching all work hours
-      url = new URL(`${process.env.SEVERA_DEMO_BASE_URL}/v1/workhours`);
+        throw new Error("severaUserId is required when severaProjectId is not specified");
       }
-      if (startDate) url.searchParams.append("startDate", startDate);
-      if (endDate) url.searchParams.append("endDate", endDate);
+      if (startTime) url.searchParams.append("startTime", startTime);
+      if (endTime) url.searchParams.append("endTime", endTime);
 
       allWorkHours = await api.getWorkHours(url);
     }

--- a/src/functions/severa/get-filtered-workhours/handler.ts
+++ b/src/functions/severa/get-filtered-workhours/handler.ts
@@ -16,6 +16,10 @@ export const getWorkHoursHandler: APIGatewayProxyHandler = async (event) => {
   try {
     const api = CreateSeveraApiService();
 
+    // Getting the list of opted in users
+    const optInUsers = await api.getOptInUsers();
+    const optInUserGuids = new Set(optInUsers.map((u) => u.guid));
+
     /**
      * Construct a custom url for fetching workHours with required queryParams.
      *
@@ -48,11 +52,15 @@ export const getWorkHoursHandler: APIGatewayProxyHandler = async (event) => {
     const url = buildWorkHoursUrl(severaProjectId, severaUserId, startDate, endDate);
     const response = await api.getWorkHours(url);
 
+    // Filtering by opted in users only
     const filteredWorkHours = response.filter((workHours: SeveraResponseWorkHours) => {
-    /**
-     * Note: If severaProjectId and severaUserId are both true, the work hours data
-     * will be filtered by project in the Severa API call due to workHours custom url.
-     */
+      if (!workHours.user?.guid || !optInUserGuids.has(workHours.user.guid)) {
+        return false;
+      }
+      /**
+       * Note: If severaProjectId and severaUserId are both true, the work hours data
+       * will be filtered by project in the Severa API call due to workHours custom url.
+       */
       if (severaProjectId && severaUserId) {
         const filteredWorkHoursUserProject = FilterUtilities.filterByUserSevera(workHours.user?.guid, severaUserId);
         if (!filteredWorkHoursUserProject) return false ;

--- a/src/functions/severa/get-filtered-workhours/handler.ts
+++ b/src/functions/severa/get-filtered-workhours/handler.ts
@@ -15,75 +15,60 @@ export const getWorkHoursHandler: APIGatewayProxyHandler = async (event) => {
 
   try {
     const api = CreateSeveraApiService();
-
     // Getting the list of opted in users
     const optInUsers = await api.getOptInUsers();
     const optInUserGuids = new Set(optInUsers.map((u) => u.guid));
 
-    /**
-     * Construct a custom url for fetching workHours with required queryParams.
-     *
-     * @param severaProjectId - Severa project id
-     * @param severaUserId - Severa user id
-     * @param startDate - Start date for work hours
-     * @param endDate - End date for work hours
-     *
-     * @returns {string} - The constructed custom URL for fetching work hours.
-     */
-    const buildWorkHoursUrl = async (severaProjectId?: string, severaUserId?: string, startDate?: string, endDate?: string) => {
-      let endpointPath: string;
-      try {
-      await api.getKeywordIdForUser(severaUserId, "isSeveraOptIn");
-    } catch {
-      return {
-        statusCode: 403,
-        body: JSON.stringify({ message: "User has not opted in." }),
-      };
-    }
-
-      if (severaProjectId) {
-        endpointPath = `projects/${severaProjectId}/workhours`;
-      } else if (severaUserId) {
-      if (severaUserId && !optInUserGuids.has(severaUserId)) {
-        throw new Error("User has not opted in.");
-      }
-        endpointPath = `users/${severaUserId}/workhours`;
+    // If severaProjectId is specified and severaUserId is not, make requests for each opted-in user
+    let allWorkHours: SeveraResponseWorkHours[] = [];
+    if (severaProjectId) {
+      // Request in parallel for each opted-in user
+      const workHoursResults = await Promise.all(
+        optInUsers.map(async (user) => {
+          try {
+            const url = new URL(`${process.env.SEVERA_DEMO_BASE_URL}/v1/users/${user.guid}/workhours`);
+            url.searchParams.append("projectGuid", severaProjectId);
+            if (startDate) url.searchParams.append("startDate", startDate);
+            if (endDate) url.searchParams.append("endDate", endDate);
+            const userWorkHours = await api.getWorkHours(url);
+            return userWorkHours;
+          } catch (e) {
+            // If there is an error for a single user, just skip
+            return [];
+          }
+        })
+      );
+      // Combine all results
+      allWorkHours = workHoursResults.flat();
+      // Filtering only for the specified project
+      allWorkHours = allWorkHours.filter(
+        (workHours) => workHours.project?.guid == severaProjectId
+      );
+    } else {
+      // Standard logic for other cases (by userId or without projectId)
+      // Manually build the URL since buildWorkHoursUrl does not exist
+      let url: URL;
+      if (severaUserId) {
+        url = new URL(`${process.env.SEVERA_DEMO_BASE_URL}/v1/users/${severaUserId}/workhours`);
       } else {
-        endpointPath = "workhours";
+      // Absolute endpoint, fetching all work hours
+      url = new URL(`${process.env.SEVERA_DEMO_BASE_URL}/v1/workhours`);
       }
+      if (severaProjectId) url.searchParams.append("projectGuid", severaProjectId);
+      if (startDate) url.searchParams.append("startDate", startDate);
+      if (endDate) url.searchParams.append("endDate", endDate);
 
-      const customUrl = new URL(`${process.env.SEVERA_DEMO_BASE_URL}/v1/${endpointPath}`);
-
-      if (startDate) customUrl.searchParams.append("startDate", startDate);
-      if (endDate) customUrl.searchParams.append("endDate", endDate);
-
-      return customUrl;
-    };
-
-    const url = await buildWorkHoursUrl(severaProjectId, severaUserId, startDate, endDate);
-    if (!(url instanceof URL)) {
-      // url is an error response object, return it directly
-      return url;
+      allWorkHours = await api.getWorkHours(url);
     }
-    const response = await api.getWorkHours(url);
 
-    // Filtering by opted in users only
-    const filteredWorkHours = response.filter((workHours: SeveraResponseWorkHours) => {
+    // Filter by opted-in users (just in case there are any "unauthorized" users in the response)
+    const filteredWorkHours = allWorkHours.filter((workHours: SeveraResponseWorkHours) => {
       if (!workHours.user?.guid || !optInUserGuids.has(workHours.user.guid)) {
         return false;
       }
-      /**
-       * Note: If severaProjectId and severaUserId are both true, the work hours data
-       * will be filtered by project in the Severa API call due to workHours custom url.
-       */
-      if (severaProjectId && severaUserId) {
-        const filteredWorkHoursUserProject = FilterUtilities.filterByUserSevera(workHours.user?.guid, severaUserId);
-        if (!filteredWorkHoursUserProject) return false ;
-      }
-
       if (severaPhaseId) {
         const filteredWorkHoursPhase = FilterUtilities.filterByPhaseSevera(workHours.phase?.guid, severaPhaseId);
-        if (!filteredWorkHoursPhase) return false ;
+        if (!filteredWorkHoursPhase) return false;
       }
       return true;
     });
@@ -118,7 +103,7 @@ export const getWorkHoursHandler: APIGatewayProxyHandler = async (event) => {
       }))
     );
 
-    const workHours = mappedWorkHours(filteredWorkHours)
+    const workHours = mappedWorkHours(filteredWorkHours);
 
     return {
       statusCode: 200,

--- a/src/functions/severa/get-filtered-workhours/handler.ts
+++ b/src/functions/severa/get-filtered-workhours/handler.ts
@@ -28,6 +28,7 @@ export const getWorkHoursHandler: APIGatewayProxyHandler = async (event) => {
         optInUsers.map(async (user) => {
           try {
             const url = new URL(`${process.env.SEVERA_DEMO_BASE_URL}/v1/users/${user.guid}/workhours`);
+            // This endpoint/query parameter is working but it is not documented proper in Severa API spec
             url.searchParams.append("projectGuid", severaProjectId);
             if (startDate) url.searchParams.append("startDate", startDate);
             if (endDate) url.searchParams.append("endDate", endDate);

--- a/src/functions/severa/get-filtered-workhours/handler.ts
+++ b/src/functions/severa/get-filtered-workhours/handler.ts
@@ -54,7 +54,6 @@ export const getWorkHoursHandler: APIGatewayProxyHandler = async (event) => {
       // Absolute endpoint, fetching all work hours
       url = new URL(`${process.env.SEVERA_DEMO_BASE_URL}/v1/workhours`);
       }
-      if (severaProjectId) url.searchParams.append("projectGuid", severaProjectId);
       if (startDate) url.searchParams.append("startDate", startDate);
       if (endDate) url.searchParams.append("endDate", endDate);
 

--- a/src/functions/severa/get-filtered-workhours/handler.ts
+++ b/src/functions/severa/get-filtered-workhours/handler.ts
@@ -11,61 +11,32 @@ import type SeveraResponseWorkHours from "src/types/severa/workHour/severaRespon
  * @param event - API Gateway event containing the userId, projectId, and phaseId.
  */
 export const getWorkHoursHandler: APIGatewayProxyHandler = async (event) => {
-  const { startDate: startDate, endDate: endDate, severaProjectId, severaPhaseId, severaUserId } = event.queryStringParameters || {};
+  const { startDate, endDate, severaProjectId, severaPhaseId, severaUserId } = event.queryStringParameters || {};
 
   try {
     const api = CreateSeveraApiService();
-    // Getting the list of opted in users
     const optInUsers = await api.getOptInUsers();
     const optInUserGuids = new Set(optInUsers.map((u) => u.guid));
 
-    let errors: Array<{ userGuid: string, error: any }> = [];
     // If severaProjectId is specified and severaUserId is not, make requests for each opted-in user
     let allWorkHours: SeveraResponseWorkHours[] = [];
     if (severaProjectId) {
-      // Request in parallel for each opted-in user
-      const workHoursResults = await Promise.all(
-        optInUsers.map(async (user) => {
-          try {
-            const url = new URL(`${process.env.SEVERA_DEMO_BASE_URL}/v1/users/${user.guid}/workhours`);
-            // This endpoint/query parameter is working but it is not documented proper in Severa API spec
-            url.searchParams.append("projectGuid", severaProjectId);
-            if (startDate) url.searchParams.append("startDate", startDate);
-            if (endDate) url.searchParams.append("endDate", endDate);
-            const userWorkHours = await api.getWorkHours(url);
-            return userWorkHours;
-          } catch (e) {
-            errors.push({ userGuid: user.guid, error: e });
-            return [];
-          }
-        })
-      );
-      // Combine all results
-      allWorkHours = workHoursResults.flat();
-      // Filtering only for the specified project
-      allWorkHours = allWorkHours.filter(
-        (workHours) => workHours.project?.guid == severaProjectId
-      );
+      allWorkHours = await api.getFilteredWorkHoursForUsers(optInUsers, severaProjectId, startDate, endDate);
+      allWorkHours = allWorkHours.filter((workHours) => workHours.project?.guid == severaProjectId);
     } else {
-      // Standard logic for other cases (by userId or without projectId)
-      // Manually build the URL since buildWorkHoursUrl does not exist
-      let url: URL;
       if (severaUserId) {
-        url = new URL(`${process.env.SEVERA_DEMO_BASE_URL}/v1/users/${severaUserId}/workhours`);
+        if (!optInUserGuids.has(severaUserId)) {
+          allWorkHours = [];
+        } else {
+          allWorkHours = await api.getWorkHoursForUser(severaUserId, startDate, endDate);
+        }
       } else {
         throw new Error("severaUserId is required when severaProjectId is not specified");
       }
-      if (startDate) url.searchParams.append("startDate", startDate);
-      if (endDate) url.searchParams.append("endDate", endDate);
-
-      allWorkHours = await api.getWorkHours(url);
     }
 
-    // Filter by opted-in users (just in case there are any "unauthorized" users in the response)
+    // Filter work hours by phase if severaPhaseId is provided
     const filteredWorkHours = allWorkHours.filter((workHours: SeveraResponseWorkHours) => {
-      if (!workHours.user?.guid || !optInUserGuids.has(workHours.user.guid)) {
-        return false;
-      }
       if (severaPhaseId) {
         const filteredWorkHoursPhase = FilterUtilities.filterByPhaseSevera(workHours.phase?.guid, severaPhaseId);
         if (!filteredWorkHoursPhase) return false;

--- a/src/functions/severa/get-resource-allocations-by-user/handler.ts
+++ b/src/functions/severa/get-resource-allocations-by-user/handler.ts
@@ -14,23 +14,45 @@ export const getResourceAllocationHandler: APIGatewayProxyHandler = async (event
 
   try {
     const api = CreateSeveraApiService();
+    // Getting the list of opted in users
+    const optInUsers = await api.getOptInUsers();
 
     const buildResourceAllocationUrl = (severaUserId?: string) => {
       let endpointPath: string;
 
       if (severaUserId) {
         endpointPath = `users/${severaUserId}/resourceallocations/allocations`;
+        const customUrl = new URL(`${process.env.SEVERA_DEMO_BASE_URL}/v1/${endpointPath}`);
+        return customUrl;
       } else {
-        endpointPath = "resourceallocations";
+        // If severaUserId is not specified, we make requests for each opted-in user and merge the results
+        return null; // special marker that we need to iterate over all opted-in
       }
-
-    const customUrl = new URL(`${process.env.SEVERA_DEMO_BASE_URL}/v1/${endpointPath}`);
-
-    return customUrl;
     }
 
     const url = buildResourceAllocationUrl(severaUserId);
-    const response = await api.getResourceAllocation(url);
+    let allResourceAllocations: SeveraResponseResourceAllocation[] = [];
+
+    if (url) {
+      // Normal case: for a specific user
+      const response = await api.getResourceAllocation(url);
+      allResourceAllocations = response;
+    } else {
+      // Like in get-filtered-workhours: we collect for all opted-in
+      const resourceAllocationsResults = await Promise.all(
+        optInUsers.map(async (user: { guid: string }) => {
+          try {
+            const userUrl = new URL(`${process.env.SEVERA_DEMO_BASE_URL}/v1/users/${user.guid}/resourceallocations/allocations`);
+            const userResourceAllocations = await api.getResourceAllocation(userUrl);
+            return userResourceAllocations;
+          } catch (e) {
+            // We can add error handling per user if needed
+            return [];
+          }
+        })
+      );
+      allResourceAllocations = resourceAllocationsResults.flat();
+    }
 
     /**
      * Maps the Severa API response data to the ResourceAllocation model.
@@ -57,9 +79,8 @@ export const getResourceAllocationHandler: APIGatewayProxyHandler = async (event
           isInternal: resourceAllocation.project?.isInternal,
         },
       }))
-  );
-  
-    const resourceAllocations = mappedResourceAllocations(response);
+    );
+    const resourceAllocations = mappedResourceAllocations(allResourceAllocations);
 
     return {
       statusCode: 200,

--- a/src/functions/severa/get-resource-allocations-by-user/handler.ts
+++ b/src/functions/severa/get-resource-allocations-by-user/handler.ts
@@ -1,5 +1,5 @@
 import type { APIGatewayProxyHandler } from "aws-lambda";
-import { CreateSeveraApiService } from "src/services/severa-api-service";
+import { CreateSeveraApiService, getResourceAllocationsByUserOrAll } from "src/services/severa-api-service";
 import { middyfy } from "src/libs/lambda";
 import type ResourceAllocationModel from "src/types/severa/resourceAllocation/resourceAllocation";
 import type SeveraResponseResourceAllocation from "src/types/severa/resourceAllocation/severaResponseResourceAllocation";
@@ -14,45 +14,9 @@ export const getResourceAllocationHandler: APIGatewayProxyHandler = async (event
 
   try {
     const api = CreateSeveraApiService();
-    // Getting the list of opted in users
     const optInUsers = await api.getOptInUsers();
 
-    const buildResourceAllocationUrl = (severaUserId?: string) => {
-      let endpointPath: string;
-
-      if (severaUserId) {
-        endpointPath = `users/${severaUserId}/resourceallocations/allocations`;
-        const customUrl = new URL(`${process.env.SEVERA_DEMO_BASE_URL}/v1/${endpointPath}`);
-        return customUrl;
-      } else {
-        // If severaUserId is not specified, we make requests for each opted-in user and merge the results
-        return null; // special marker that we need to iterate over all opted-in
-      }
-    }
-
-    const url = buildResourceAllocationUrl(severaUserId);
-    let allResourceAllocations: SeveraResponseResourceAllocation[] = [];
-
-    if (url) {
-      // Normal case: for a specific user
-      const response = await api.getResourceAllocation(url);
-      allResourceAllocations = response;
-    } else {
-      // Like in get-filtered-workhours: we collect for all opted-in
-      const resourceAllocationsResults = await Promise.all(
-        optInUsers.map(async (user: { guid: string }) => {
-          try {
-            const userUrl = new URL(`${process.env.SEVERA_DEMO_BASE_URL}/v1/users/${user.guid}/resourceallocations/allocations`);
-            const userResourceAllocations = await api.getResourceAllocation(userUrl);
-            return userResourceAllocations;
-          } catch (e) {
-            // We can add error handling per user if needed
-            return [];
-          }
-        })
-      );
-      allResourceAllocations = resourceAllocationsResults.flat();
-    }
+    const allResourceAllocations = await getResourceAllocationsByUserOrAll(severaUserId, optInUsers);
 
     /**
      * Maps the Severa API response data to the ResourceAllocation model.

--- a/src/services/severa-api-service.ts
+++ b/src/services/severa-api-service.ts
@@ -23,6 +23,8 @@ export interface SeveraApiService {
   getResourceAllocations: () => Promise<SeveraResponseResourceAllocation>;
   getUser: (severaUserId: string) => Promise<SeveraResponseUser>;
   getKeywordIdForUser: (severaUserId: string, keywordValue: string) => Promise<string>;
+  getFilteredWorkHoursForUsers: (users: { guid: string }[], severaProjectId: string, startDate?: string, endDate?: string) => Promise<SeveraResponseWorkHours[]>;
+  getWorkHoursForUser: (severaUserId: string, startDate?: string, endDate?: string) => Promise<SeveraResponseWorkHours[]>;
 }
 
 /**
@@ -284,7 +286,70 @@ export const CreateSeveraApiService = (): SeveraApiService => {
       }
 
       return match.guid;
+    },
+
+    /**
+     * Gets work hours for multiple users filtered by project and dates.
+     *
+     * @param users Array of users (must have .guid)
+     * @param severaProjectId Project GUID
+     * @param startDate Optional start date
+     * @param endDate Optional end date
+     * @returns Array of work hours for all users
+     */
+    getFilteredWorkHoursForUsers: async (
+      users,
+      severaProjectId,
+      startDate,
+      endDate
+    ) => {
+      const errors: Array<{ userGuid: string, error: any }> = [];
+      const workHoursResults = await Promise.all(
+        users.map(async (user) => {
+          try {
+            const url = new URL(`${baseUrl}/v1/users/${user.guid}/workhours`);
+            // This endpoint/query parameter is working but it is not documented proper in Severa API spec
+            url.searchParams.append("projectGuid", severaProjectId);
+            if (startDate) url.searchParams.append("startDate", startDate);
+            if (endDate) url.searchParams.append("endDate", endDate);
+            const userWorkHours = await (await fetch(url.toString(), {
+              method: "GET",
+              headers: {
+                Authorization: `Bearer ${await getSeveraAccessToken()}`,
+                Client_Id: process.env.SEVERA_DEMO_CLIENT_ID,
+                "Content-Type": "application/json"
+              }
+            })).json();
+            return userWorkHours;
+          } catch (e) {
+            errors.push({ userGuid: user.guid, error: e });
+            return [];
+          }
+        })
+      );
+      return workHoursResults.flat();
+    },
+
+    getWorkHoursForUser: async (severaUserId, startDate, endDate) => {
+      const url = new URL(`${process.env.SEVERA_DEMO_BASE_URL}/v1/users/${severaUserId}/workhours`);
+      if (startDate) url.searchParams.append("startDate", startDate);
+      if (endDate) url.searchParams.append("endDate", endDate);
+
+      const response = await fetch(url.toString(), {
+        method: "GET",
+        headers: {
+          Authorization: `Bearer ${await getSeveraAccessToken()}`,
+          Client_Id: process.env.SEVERA_DEMO_CLIENT_ID,
+          "Content-Type": "application/json"
+        }
+      });
+
+      if (!response.ok) {
+        throw new Error(`Failed to fetch work hours: ${response.status} - ${response.statusText}`);
+      }
+      return response.json();
     }
+
   };
 };
 
@@ -477,3 +542,61 @@ export const updateSeveraOptInKeyword = async (
 
   return await updateResponse.json();
 };
+
+/**
+ * Gets resource allocations for a specific user or for all opt-in users if no user is specified.
+ *
+ * @param severaUserId - The GUID of the Severa user (optional).
+ * @param optInUsers - Array of opted-in users ({ guid: string }[]).
+ * @returns {Promise<SeveraResponseResourceAllocation[]>} - Array of resource allocations.
+ */
+export async function getResourceAllocationsByUserOrAll(
+  severaUserId: string | undefined,
+  optInUsers: { guid: string }[]
+): Promise<SeveraResponseResourceAllocation[]> {
+  const api = CreateSeveraApiService();
+
+  /**
+   * Builds the resource allocation URL for a specific user or returns null if no user is specified.
+   *
+   * @param severaUserId - The GUID of the Severa user.
+   * @returns {URL | null} - The constructed URL for the user's resource allocations, or null if severaUserId is not provided.
+   */
+  const buildResourceAllocationUrl = (severaUserId?: string): URL | null => {
+    let endpointPath: string;
+
+    if (severaUserId) {
+      endpointPath = `users/${severaUserId}/resourceallocations/allocations`;
+      const customUrl = new URL(`${process.env.SEVERA_DEMO_BASE_URL}/v1/${endpointPath}`);
+      return customUrl;
+    } else {
+      // If severaUserId is not specified, we make requests for each opted-in user and merge the results
+      return null; // special marker that we need to iterate over all opted-in
+    }
+  };
+
+  const url = buildResourceAllocationUrl(severaUserId);
+  let allResourceAllocations: SeveraResponseResourceAllocation[] = [];
+
+  if (url) {
+    // Normal case: for a specific user
+    const response = await api.getResourceAllocation(url);
+    allResourceAllocations = response;
+  } else {
+    const resourceAllocationsResults = await Promise.all(
+      optInUsers.map(async (user: { guid: string }) => {
+        try {
+          const userUrl = new URL(`${process.env.SEVERA_DEMO_BASE_URL}/v1/users/${user.guid}/resourceallocations/allocations`);
+          const userResourceAllocations = await api.getResourceAllocation(userUrl);
+          return userResourceAllocations;
+        } catch (e) {
+          console.error(`Error fetching resource allocations for user ${user.guid}:`, e);
+          return [];
+        }
+      })
+    );
+    allResourceAllocations = resourceAllocationsResults.flat();
+  }
+
+  return allResourceAllocations;
+}

--- a/src/services/severa-api-service.ts
+++ b/src/services/severa-api-service.ts
@@ -394,6 +394,15 @@ export const CreateSeveraApiService = (): SeveraApiService => {
       return workHoursResults.flat();
     },
 
+    /**
+     * Fetches work hours for a specific user from Severa API.
+     *
+     * @param severaUserId - The GUID of the Severa user whose work hours are being retrieved.
+     * @param startDate - (Optional) The start date for filtering work hours (ISO format).
+     * @param endDate - (Optional) The end date for filtering work hours (ISO format).
+     * @returns {Promise<SeveraResponseWorkHours[]>} - A promise that resolves to an array of work hours for the specified user.
+     * @throws {Error} If the request to the Severa API fails.
+     */
     getWorkHoursForUser: async (severaUserId, startDate, endDate) => {
       const url = new URL(`${process.env.SEVERA_DEMO_BASE_URL}/v1/users/${severaUserId}/workhours`);
       if (startDate) url.searchParams.append("startDate", startDate);


### PR DESCRIPTION
### Function: `getWorkHoursHandler` (`src/functions/severa/get-filtered-workhours/handler.ts`)
**Purpose:**  
Returns Severa users' work hours, with filtering by project, phase, user, and includes only opted-in users.

---

### Key Features

#### Filtering Only Opted-In Users
- Retrieves a list of users who have opted in for data processing.
- All requests to the Severa API are made **only** for these users.

#### Flexible Parameter Filtering
- Supports the following filters: `severaProjectId`, `severaPhaseId`, `severaUserId`, `startDate`, `endDate`.
- If `severaProjectId` is specified (and `severaUserId` is not), a **separate API request** is made for each opted-in user, filtered by project.
- If `severaUserId` is specified, the API request is made **only for that user**.
- If neither project nor user is specified, a general endpoint is used (defined in the code, but may be commented out).

#### Explicit Project Filtering
- After retrieving all work hours for opted-in users, the results are **further filtered** to include only records where `project.guid` strictly matches the provided `severaProjectId`.
- This ensures no extraneous records are returned, even if Severa API or mock data includes more than necessary.

#### Phase Filtering
- If `severaPhaseId` is provided, work hours are further filtered by the corresponding project phase.

**How to test getWorkHoursHandler?**

To run test on local backend, you can run - `npx sls invoke local -f getWorkHoursHandler --stage dev --path src/tests/serverless/mockData.json`

mockData:

```
"queryStringParameters": {
    "severaProjectId": "PROJECT_ID"
  }
```

Possible project IDs:
```
f7d6b20f-20a7-8abc-b9af-527537a6f197
7f981300-a213-bdd3-5a2c-2f05441ce29a
334a66c6-cb35-fb03-b209-18626a31047e
```
---
### Function: `getResourceAllocationHandler` (`handler.ts`)
**Purpose:**  
Returns Severa users' resource allocations, including only opted-in users. Supports filtering by user.

---

### Key Features

#### Filtering Only Opted-In Users
- Retrieves a list of users who have explicitly opted in.
- All requests to the Severa API are made **only for these users**.

#### Flexible User Filtering
- Supports the `severaUserId` filter (via query string).
- If `severaUserId` is provided, the Severa API request is made **only for that user**.
- If `severaUserId` is not provided, a **separate request** is made for **each** opted-in user, and the results are combined.

#### Batch Requests for All Opted-In Users
- To retrieve resource allocations for **all** opted-in users, the function makes **parallel API requests** to Severa for each user.
- All results are merged into a single array before being returned to the client.

#### Consistent Data Mapping
- After fetching data from the Severa API, all resource allocations are mapped into a unified internal format: `ResourceAllocationModel`.

**How to test getResourceAllocationHandler?**

To run test on local backend, you can run - `npx sls invoke local -f getResourceAllocationHandler --stage dev --path src/tests/serverless/mockData.json`

For testing through **POSTMAN**, run backend localy and use this url - `http://localhost:3000/dev/severa/resourceAllocations?severaUserId`
`http://localhost:3000/dev/severa/resourceAllocations?severaUserId=USER_ID`