### PR TITLE
Feature-184-on-call-setup

### DIFF
--- a/serverless.ts
+++ b/serverless.ts
@@ -346,6 +346,42 @@ const serverlessConfiguration: AWS = {
           }
         }
       },
+      OnCallSchedule: {
+        Type: "AWS::DynamoDB::Table",
+        DeletionPolicy: "Delete",
+        Properties: {
+          TableName: "OnCallSchedule",
+          AttributeDefinitions: [
+            { AttributeName: "Year", AttributeType: "N" },
+            { AttributeName: "Week", AttributeType: "N" }
+          ],
+          KeySchema: [
+            { AttributeName: "Year", KeyType: "HASH" },
+            { AttributeName: "Week", KeyType: "RANGE" }
+          ],
+          ProvisionedThroughput: {
+            ReadCapacityUnits: 1,
+            WriteCapacityUnits: 1
+          }
+        }
+      },
+      OnCallNameMap: {
+        Type: "AWS::DynamoDB::Table",
+        DeletionPolicy: "Delete",
+        Properties: {
+          TableName: "OnCallNameMap",
+          AttributeDefinitions: [
+            { AttributeName: "Username", AttributeType: "S" }
+          ],
+          KeySchema: [
+            { AttributeName: "Username", KeyType: "HASH" }
+          ],
+          ProvisionedThroughput: {
+            ReadCapacityUnits: 1,
+            WriteCapacityUnits: 1
+          }
+        }
+      },
     },
   },
 };

--- a/serverless.ts
+++ b/serverless.ts
@@ -365,23 +365,6 @@ const serverlessConfiguration: AWS = {
           }
         }
       },
-      OnCallNameMap: {
-        Type: "AWS::DynamoDB::Table",
-        DeletionPolicy: "Delete",
-        Properties: {
-          TableName: "OnCallNameMap",
-          AttributeDefinitions: [
-            { AttributeName: "Username", AttributeType: "S" }
-          ],
-          KeySchema: [
-            { AttributeName: "Username", KeyType: "HASH" }
-          ],
-          ProvisionedThroughput: {
-            ReadCapacityUnits: 1,
-            WriteCapacityUnits: 1
-          }
-        }
-      },
     },
   },
 };

--- a/src/database/models/oncall.ts
+++ b/src/database/models/oncall.ts
@@ -1,0 +1,6 @@
+export interface OnCallEntry {
+  Year: number;
+  Week: number;
+  Person: string;
+  Paid?: boolean;
+}

--- a/src/functions/on-call/list-on-call-data/handler.ts
+++ b/src/functions/on-call/list-on-call-data/handler.ts
@@ -1,6 +1,7 @@
 import { DynamoDB } from "aws-sdk"
 import { middyfy } from "@libs/lambda";
 import { ValidatedEventAPIGatewayProxyEvent } from "src/libs/api-gateway";
+import { OnCallEntry } from "src/database/models/oncall";
 
 /**
  * Lambda method for loading on-call data
@@ -27,7 +28,7 @@ export const listOnCallDataHandler: ValidatedEventAPIGatewayProxyEvent<any> = as
 
   const dynamoDb = new DynamoDB.DocumentClient();
 
-  // Получаем все записи за указанный год
+  // Get data for the specified year
   const dataResult = await dynamoDb.query({
     TableName: "OnCallSchedule",
     KeyConditionExpression: "#yr = :year",
@@ -39,17 +40,7 @@ export const listOnCallDataHandler: ValidatedEventAPIGatewayProxyEvent<any> = as
     }
   }).promise();
 
-  const data = dataResult.Items || [];
-
-  // Загружаем nameMap из отдельной таблицы
-  const nameMapResult = await dynamoDb.scan({
-    TableName: "OnCallNameMap"
-  }).promise();
-
-  const nameMap: { [key: string]: string } = {};
-  (nameMapResult.Items || []).forEach(item => {
-    nameMap[item.Username] = item.FullName;
-  });
+  const data = (dataResult.Items as OnCallEntry[]) || [];
 
   if (!data.length) {
     return {
@@ -60,9 +51,9 @@ export const listOnCallDataHandler: ValidatedEventAPIGatewayProxyEvent<any> = as
 
   return {
     statusCode: 200,
-    body: JSON.stringify(data.map((entry: any) => ({
+    body: JSON.stringify(data.map((entry) => ({
       ...entry,
-      Person: nameMap[entry.Person] || entry.Person,
+      Person: entry.Person,
       Paid: entry.Paid || false
     })))
   };

--- a/src/functions/on-call/list-on-call-data/handler.ts
+++ b/src/functions/on-call/list-on-call-data/handler.ts
@@ -1,8 +1,5 @@
-import { S3 } from "aws-sdk"
-import { OnCallEntry, PaidData } from "../../../types/on-call";
-import S3Utils from "@libs/s3-utils";
+import { DynamoDB } from "aws-sdk"
 import { middyfy } from "@libs/lambda";
-import Config from "../../../app/config";
 import { ValidatedEventAPIGatewayProxyEvent } from "src/libs/api-gateway";
 
 /**
@@ -28,18 +25,33 @@ export const listOnCallDataHandler: ValidatedEventAPIGatewayProxyEvent<any> = as
     }
   }
 
-  const s3 = new S3();
+  const dynamoDb = new DynamoDB.DocumentClient();
 
-  const nameMapFile = "name-map.json";
-  const yearFile = `${year}.json`;
-  const paidFile = "paid.json";
+  // Получаем все записи за указанный год
+  const dataResult = await dynamoDb.query({
+    TableName: "OnCallSchedule",
+    KeyConditionExpression: "#yr = :year",
+    ExpressionAttributeNames: {
+      "#yr": "Year"
+    },
+    ExpressionAttributeValues: {
+      ":year": year
+    }
+  }).promise();
 
-  const bucket = Config.get().onCall.bucketName;
-  const nameMap = await S3Utils.loadJson<{ [key: string]: string }>(s3, bucket, nameMapFile) || {};
-  const data = await S3Utils.loadJson<OnCallEntry[]>(s3, bucket, yearFile);
-  const paidData = await S3Utils.loadJson<PaidData>(s3, bucket, paidFile) || {};
+  const data = dataResult.Items || [];
 
-  if (!data || !nameMap || !paidData) {
+  // Загружаем nameMap из отдельной таблицы
+  const nameMapResult = await dynamoDb.scan({
+    TableName: "OnCallNameMap"
+  }).promise();
+
+  const nameMap: { [key: string]: string } = {};
+  (nameMapResult.Items || []).forEach(item => {
+    nameMap[item.Username] = item.FullName;
+  });
+
+  if (!data.length) {
     return {
       statusCode: 204,
       body: "No content"
@@ -48,13 +60,11 @@ export const listOnCallDataHandler: ValidatedEventAPIGatewayProxyEvent<any> = as
 
   return {
     statusCode: 200,
-    body: JSON.stringify(data.map((entry: any) => {
-      return {
-        ...entry,
-        Person: nameMap[entry.Person] || entry.Person,
-        Paid: paidData[year] && paidData[year][entry.Week] || false
-      }
-    }))
+    body: JSON.stringify(data.map((entry: any) => ({
+      ...entry,
+      Person: nameMap[entry.Person] || entry.Person,
+      Paid: entry.Paid || false
+    })))
   };
 }
 

--- a/src/functions/on-call/update-paid/handler.ts
+++ b/src/functions/on-call/update-paid/handler.ts
@@ -25,7 +25,6 @@ export const updatePaidHandler: ValidatedEventAPIGatewayProxyEvent<any> = async 
 
   const dynamoDb = new DynamoDB.DocumentClient();
 
-  // Update only after Set Paid for record direct Year adn Week
   await dynamoDb.update({
     TableName: "OnCallSchedule",
     Key: {

--- a/src/functions/on-call/update-paid/handler.ts
+++ b/src/functions/on-call/update-paid/handler.ts
@@ -1,7 +1,5 @@
-import { S3 } from "aws-sdk"
-import { PaidData, UpdatePaidRequestBody } from "../../../types/on-call"
-import S3Utils from "@libs/s3-utils";
-import Config from "src/app/config";
+import { DynamoDB } from "aws-sdk"
+import { UpdatePaidRequestBody } from "../../../types/on-call"
 import { middyfy } from "@libs/lambda";
 import { ValidatedEventAPIGatewayProxyEvent } from "src/libs/api-gateway";
 
@@ -25,19 +23,25 @@ export const updatePaidHandler: ValidatedEventAPIGatewayProxyEvent<any> = async 
     throw new Error("Invalid paid status");
   }
 
-  const s3 = new S3();
-  const bucket = Config.get().onCall.bucketName;
-  const paidFile = "paid.json";
+  const dynamoDb = new DynamoDB.DocumentClient();
 
-  const paidData = await S3Utils.loadJson<PaidData>(s3, bucket, paidFile) || {};
-  if (!paidData[year]) paidData[year] = {}
-  paidData[year][week] = paid;
-  await S3Utils.saveJson(s3, bucket, paidFile, paidData);
+  // Update only after Set Paid for record direct Year adn Week
+  await dynamoDb.update({
+    TableName: "OnCallSchedule",
+    Key: {
+      Year: year,
+      Week: week
+    },
+    UpdateExpression: "set Paid = :paid",
+    ExpressionAttributeValues: {
+      ":paid": paid
+    }
+  }).promise();
 
   return {
     statusCode: 200,
     body: "Paid status updated"
   };
-
 };
+
 export const main = middyfy(updatePaidHandler);

--- a/src/functions/on-call/weekly-check/handler.ts
+++ b/src/functions/on-call/weekly-check/handler.ts
@@ -4,6 +4,7 @@ import { DateTime } from "luxon";
 import Config from "src/app/config";
 import { SplunkSchedule } from "src/types/on-call";
 import { ValidatedEventAPIGatewayProxyEvent } from "src/libs/api-gateway";
+import { OnCallEntry } from "src/database/models/oncall";
 
 /**
  * Resolve next week from schedule
@@ -58,14 +59,17 @@ export const weeklyCheckHandler : ValidatedEventAPIGatewayProxyEvent<any> = asyn
   const week = nextWeek.week;
   const person = nextWeek.user;
 
+  const entry: OnCallEntry = {
+    Year: year,
+    Week: week,
+    Person: person,
+    Paid: false
+  };
+
   // Update or create a new record in DynamoDB
   await dynamoDb.put({
     TableName: "OnCallSchedule",
-    Item: {
-      Year: year,
-      Week: week,
-      Person: person
-    }
+    Item: entry
   }).promise();
 
   return {

--- a/src/functions/on-call/weekly-check/handler.ts
+++ b/src/functions/on-call/weekly-check/handler.ts
@@ -1,9 +1,8 @@
-import { S3 } from "aws-sdk"
+import { DynamoDB} from "aws-sdk"
 import fetch from "node-fetch";
 import { DateTime } from "luxon";
-import S3Utils from "@libs/s3-utils";
 import Config from "src/app/config";
-import { OnCallEntry, SplunkSchedule } from "src/types/on-call";
+import { SplunkSchedule } from "src/types/on-call";
 import { ValidatedEventAPIGatewayProxyEvent } from "src/libs/api-gateway";
 
 /**
@@ -54,22 +53,20 @@ export const weeklyCheckHandler : ValidatedEventAPIGatewayProxyEvent<any> = asyn
     throw new Error("Next week not found");
   }
 
-  const yearFile = `${nextThursday.year}.json`;
-  const s3 = new S3();
-  const bucket = Config.get().onCall.bucketName;
-  const yearJson = (await S3Utils.loadJson<OnCallEntry[]>(s3, bucket, yearFile)) || [];
+  const dynamoDb = new DynamoDB.DocumentClient();
+  const year = nextThursday.year;
+  const week = nextWeek.week;
+  const person = nextWeek.user;
 
-  const selectedWeekIndex = yearJson.findIndex(entry => entry.Week == nextWeek.week);
-  if (selectedWeekIndex > -1) {
-    yearJson[selectedWeekIndex].Person = nextWeek.user;
-  } else {
-    yearJson.push({
-      Week: nextWeek.week,
-      Person: nextWeek.user
-    });
-  }
-
-  await S3Utils.saveJson(s3, bucket, yearFile, yearJson);
+  // Update or create a new record in DynamoDB
+  await dynamoDb.put({
+    TableName: "OnCallSchedule",
+    Item: {
+      Year: year,
+      Week: week,
+      Person: person
+    }
+  }).promise();
 
   return {
     statusCode: 200,

--- a/src/functions/on-call/weekly-check/index.ts
+++ b/src/functions/on-call/weekly-check/index.ts
@@ -4,9 +4,17 @@ const { ONCALL_WEEKLY_SCHEDULE_TIMER } = process.env;
 
 export default {
   handler: `${handlerPath(__dirname)}/handler.main`,
-  events: ONCALL_WEEKLY_SCHEDULE_TIMER ? [
+  events: [
+    ...(ONCALL_WEEKLY_SCHEDULE_TIMER ? [
+      {
+        schedule: ONCALL_WEEKLY_SCHEDULE_TIMER,
+      }
+    ] : []),
     {
-      schedule: ONCALL_WEEKLY_SCHEDULE_TIMER,
+      httpApi: {
+        path: "/on-call/weekly-check",
+        method: "get"
+      }
     }
-  ] : []
+  ]
 };

--- a/src/functions/on-call/weekly-check/index.ts
+++ b/src/functions/on-call/weekly-check/index.ts
@@ -10,11 +10,5 @@ export default {
         schedule: ONCALL_WEEKLY_SCHEDULE_TIMER,
       }
     ] : []),
-    {
-      httpApi: {
-        path: "/on-call/weekly-check",
-        method: "get"
-      }
-    }
   ]
 };


### PR DESCRIPTION
**To test this function**, I recommend creating a docker container in which to run an instance of DynamoDB.

`sudo docker run -p 8000:8000 amazon/dynamodb-local -jar DynamoDBLocal.jar -inMemory -sharedDb`

`aws configure`

`aws dynamodb create-table   --table-name OnCallSchedule   --attribute-definitions AttributeName=Year,AttributeType=N AttributeName=Week,AttributeType=N   --key-schema AttributeName=Year,KeyType=HASH AttributeName=Week,KeyType=RANGE   --provisioned-throughput ReadCapacityUnits=1,WriteCapacityUnits=1   --endpoint-url http://localhost:8000`

`aws dynamodb create-table   --table-name OnCallNameMap   --attribute-definitions AttributeName=Username,AttributeType=S   --key-schema AttributeName=Username,KeyType=HASH   --provisioned-throughput ReadCapacityUnits=1,WriteCapacityUnits=1   --endpoint-url http://localhost:8000`

`aws dynamodb list-tables --endpoint-url http://localhost:8000`

and change the connection when creating a new instance of DynamoDB

```
const dynamoDb = new DynamoDB.DocumentClient({
        endpoint: "http://localhost:8000",
        region: "local",
        accessKeyId: "fakeMyKeyId",
        secretAccessKey: "fakeSecretAccessKey"
      });
```