### PR TITLE
feature-218-missing-software-admin-screen

### DIFF
--- a/src/functions/software-registry/delete-software/handler.ts
+++ b/src/functions/software-registry/delete-software/handler.ts
@@ -3,7 +3,7 @@ import { DynamoDBClient } from "@aws-sdk/client-dynamodb";
 import { DynamoDBDocumentClient } from "@aws-sdk/lib-dynamodb";
 import SoftwareService from "src/database/services/software-service";
 import { middyfy } from "src/libs/lambda";
-import * as jwt from 'jsonwebtoken';
+import { isAdminUser } from "src/libs/auth-utils";
 
 const dynamoClient = new DynamoDBClient({});
 const docClient = DynamoDBDocumentClient.from(dynamoClient);
@@ -16,57 +16,15 @@ const softwareService = new SoftwareService(docClient);
  */
 export const deleteSoftwareHandler: APIGatewayProxyHandler = async (event: APIGatewayProxyEvent) => {
   console.log('Received event:', JSON.stringify(event));
-
-  const authHeader = event.headers.Authorization || event.headers.authorization;
-  if (!authHeader) {
-    console.error("Missing Authorization header.");
-    return {
-      statusCode: 401,
-      body: JSON.stringify({ error: 'Unauthorized. Authorization header is missing.' }),
-    };
-  }
-
-  const token = authHeader.split(' ')[1];
-  if (!token) {
-    console.error("Missing token in Authorization header.");
-    return {
-      statusCode: 401,
-      body: JSON.stringify({ error: 'Unauthorized. Token is missing.' }),
-    };
-  }
-
-  const decodedToken = jwt.decode(token) as { realm_access?: { roles: string[] } } | null;
-  if (!decodedToken) {
-    console.error("Invalid token or unable to decode.");
-    return {
-      statusCode: 401,
-      body: JSON.stringify({ error: 'Unauthorized. Invalid token.' }),
-    };
-  }
-
-  console.log('Decoded JWT Token:', JSON.stringify(decodedToken, null, 2));
-
-  const realmRoles = decodedToken.realm_access?.roles || [];
-  if (realmRoles.length === 0) {
-    console.log('No roles found in realm_access.');
+  if (!isAdminUser(event)) {
     return {
       statusCode: 403,
-      body: JSON.stringify({ error: 'Forbidden. No roles found.' }),
+      body: JSON.stringify({
+        code: 403,
+        message: "Access denied. Admin privileges required.",
+      }),
     };
   }
-
-  console.log('User roles:', realmRoles);
-
-  const isAdmin = realmRoles.includes('admin');
-  console.log(isAdmin);
-  if (!isAdmin) {
-    console.log('User does not have admin privileges. Permission denied.');
-    return {
-      statusCode: 403,
-      body: JSON.stringify({ error: 'Forbidden. Admin privileges required.' }),
-    };
-  }
-
   const { id } = event.pathParameters || {};
   console.log('Path parameter (id):', id);
 

--- a/src/functions/software-registry/update-software/handler.ts
+++ b/src/functions/software-registry/update-software/handler.ts
@@ -2,10 +2,9 @@ import { DynamoDBClient } from "@aws-sdk/client-dynamodb";
 import { DynamoDBDocumentClient } from "@aws-sdk/lib-dynamodb";
 import SoftwareService from "src/database/services/software-service";
 import { middyfy } from "src/libs/lambda";
-import { getAuthDataFromToken } from "src/libs/auth-utils"
+import { getAuthDataFromToken, isAdminUser} from "src/libs/auth-utils"
 import { SoftwareModel } from "src/database/models/software";
 import { ValidatedEventAPIGatewayProxyEvent } from "src/libs/api-gateway";
-import { isAdminUser } from "src/libs/auth-utils";
 
 const dynamoClient = new DynamoDBClient({});
 const docClient = DynamoDBDocumentClient.from(dynamoClient);

--- a/src/functions/software-registry/update-software/handler.ts
+++ b/src/functions/software-registry/update-software/handler.ts
@@ -5,6 +5,7 @@ import { middyfy } from "src/libs/lambda";
 import { getAuthDataFromToken } from "src/libs/auth-utils"
 import { SoftwareModel } from "src/database/models/software";
 import { ValidatedEventAPIGatewayProxyEvent } from "src/libs/api-gateway";
+import * as jwt from "jsonwebtoken"
 
 const dynamoClient = new DynamoDBClient({});
 const docClient = DynamoDBDocumentClient.from(dynamoClient);
@@ -22,6 +23,35 @@ export const updateSoftwareHandler: ValidatedEventAPIGatewayProxyEvent<SoftwareM
   try {
     const { id } = event.pathParameters || {};
     console.log('Path parameter (id):', id);
+    const authorizationHeader = event.headers?.authorization;
+    if (!authorizationHeader) 
+        return {
+          statusCode: 400,
+          body: JSON.stringify({
+            code: 400,
+            message: "Missing Authorization header.",
+          }),
+        }
+
+    const token = authorizationHeader.split(' ')[1];
+    if (!token) 
+      return {
+        statusCode: 400,
+        body: JSON.stringify({
+          code: 400,
+          message: "Missing Bearer token.",
+        }),
+      }
+
+    const decodedJWT = jwt.decode(token);
+    if (!decodedJWT.realm_access.roles.includes("admin")) 
+      return {
+        statusCode: 403,
+        body: JSON.stringify({
+          code: 403,
+          message: "Access denied. Admin privileges required.",
+        }),
+      }
 
     if (!id) {
       return {
@@ -36,7 +66,7 @@ export const updateSoftwareHandler: ValidatedEventAPIGatewayProxyEvent<SoftwareM
         body: JSON.stringify({ error: 'Request body is required.' }),
       };
     }
-
+    
     let data: SoftwareModel;
     if (typeof event.body === 'string') {
       data = JSON.parse(event.body);

--- a/src/functions/software-registry/update-software/handler.ts
+++ b/src/functions/software-registry/update-software/handler.ts
@@ -5,7 +5,7 @@ import { middyfy } from "src/libs/lambda";
 import { getAuthDataFromToken } from "src/libs/auth-utils"
 import { SoftwareModel } from "src/database/models/software";
 import { ValidatedEventAPIGatewayProxyEvent } from "src/libs/api-gateway";
-import * as jwt from "jsonwebtoken"
+import { isAdminUser } from "src/libs/auth-utils";
 
 const dynamoClient = new DynamoDBClient({});
 const docClient = DynamoDBDocumentClient.from(dynamoClient);
@@ -23,36 +23,15 @@ export const updateSoftwareHandler: ValidatedEventAPIGatewayProxyEvent<SoftwareM
   try {
     const { id } = event.pathParameters || {};
     console.log('Path parameter (id):', id);
-    const authorizationHeader = event.headers?.authorization;
-    if (!authorizationHeader) 
-        return {
-          statusCode: 400,
-          body: JSON.stringify({
-            code: 400,
-            message: "Missing Authorization header.",
-          }),
-        }
-
-    const token = authorizationHeader.split(' ')[1];
-    if (!token) 
-      return {
-        statusCode: 400,
-        body: JSON.stringify({
-          code: 400,
-          message: "Missing Bearer token.",
-        }),
-      }
-
-    const decodedJWT = jwt.decode(token);
-    if (!decodedJWT.realm_access.roles.includes("admin")) 
-      return {
-        statusCode: 403,
-        body: JSON.stringify({
-          code: 403,
-          message: "Access denied. Admin privileges required.",
-        }),
-      }
-
+    if (!isAdminUser(event)) {
+    return {
+      statusCode: 403,
+      body: JSON.stringify({
+        code: 403,
+        message: "Access denied. Admin privileges required.",
+      }),
+    };
+  }
     if (!id) {
       return {
         statusCode: 400,

--- a/src/functions/wiki-documentation/delete-article/handler.ts
+++ b/src/functions/wiki-documentation/delete-article/handler.ts
@@ -3,7 +3,7 @@ import { DynamoDBClient } from "@aws-sdk/client-dynamodb";
 import { DynamoDBDocumentClient } from "@aws-sdk/lib-dynamodb";
 import ArticlesApiService from "src/database/services/articles-api-service";
 import { middyfy } from "src/libs/lambda";
-import * as jwt from 'jsonwebtoken';
+import { isAdminUser } from "src/libs/auth-utils";
 
 const dynamoClient = new DynamoDBClient({});
 const docClient = DynamoDBDocumentClient.from(dynamoClient);
@@ -15,36 +15,15 @@ const articleService = new ArticlesApiService(docClient);
  * @param event - API Gateway event.
  */
 const deleteArticleHandler: APIGatewayProxyHandler = async (event: APIGatewayProxyEvent) => {
-  const authorizationHeader = event.headers?.Authorization;
-  if (!authorizationHeader) 
-    return {
-      statusCode: 400,
-      body: JSON.stringify({
-        code: 400,
-        message: "Missing Authorization header.",
-      }),
-    }
-
-  const token = authorizationHeader.split(' ')[1];
-  if (!token) 
-    return {
-      statusCode: 400,
-      body: JSON.stringify({
-        code: 400,
-        message: "Missing Bearer token.",
-      }),
-    }
-
-  const decodedJWT = jwt.decode(token);
-  if (!decodedJWT.realm_access.roles.includes("admin")) 
+  if (!isAdminUser(event)) {
     return {
       statusCode: 403,
       body: JSON.stringify({
         code: 403,
         message: "Access denied. Admin privileges required.",
       }),
-    }
-
+    };
+  }
   const { id } = event.pathParameters || {};
   if (!id) {
     return {

--- a/src/libs/auth-utils.ts
+++ b/src/libs/auth-utils.ts
@@ -3,6 +3,9 @@ import * as jwt from 'jsonwebtoken';
 
 interface DecodedToken {
   sub: string;
+  realm_access?: {
+    roles: string[];
+  };
 }
 
 /**
@@ -48,3 +51,20 @@ export const getAuthDataFromToken = (event: { headers: APIGatewayProxyEvent['hea
     return null;
   }
 };
+/**
+ * Helper function to check if the user has the "admin" role.
+ * 
+ * @param event - The API Gateway event containing the headers.
+ * @returns True if the user has the "admin" role, false otherwise.
+ */
+export const isAdminUser = (
+  event: { headers: APIGatewayProxyEvent['headers'] }
+): boolean => {
+  const decoded = getAuthDataFromToken(event);
+  if (!decoded) {
+    return false;
+  }
+  const roles = decoded.realm_access?.roles || [];
+  return roles.includes("admin");
+};
+


### PR DESCRIPTION
Moved the logic for checking if user is admin to auth-utils and now it can be fetched when needed to authenticate users role. Used the function in update/delete-software and delete-article handlers