### PR TITLE
Feature 247 vacations consume user vaction days

### DIFF
--- a/src/functions/vacation-request/create-vacation-request/handler.ts
+++ b/src/functions/vacation-request/create-vacation-request/handler.ts
@@ -1,9 +1,10 @@
 import { vacationRequestService } from "src/database/services";
 import { CreateKeycloakApiService } from "src/database/services/keycloak-api-service";
-import type { VacationRequest } from "src/generated/homeLambdasModels/model/vacationRequest";
 import type { ValidatedEventAPIGatewayProxyEvent } from "src/libs/api-gateway";
 import { middyfy } from "src/libs/lambda";
+import { splitVacationDaysByYear, updateRemainingVacationDays } from "src/libs/vacation-utils";
 import { notifyAdminsVacationSubmittedAll } from "src/notifications/vacation-notifications";
+import type vacationRequestSchema from "src/schema/vacationRequest";
 import { v4 as uuidv4 } from "uuid";
 
 /**
@@ -16,7 +17,7 @@ import { v4 as uuidv4 } from "uuid";
  * - 'createdAt', 'updatedAt', 'startDate', 'endDate' are 'string' here, but VacationRequest expects 'Date'.
  */
 export const createVacationRequestHandler: ValidatedEventAPIGatewayProxyEvent<
-  VacationRequest
+  typeof vacationRequestSchema
 > = async (event) => {
   const { body } = event;
   if (!body) {
@@ -77,6 +78,21 @@ export const createVacationRequestHandler: ValidatedEventAPIGatewayProxyEvent<
       createdAt: createdAt,
       updatedAt: updatedAt
     });
+
+    const daysByYear = splitVacationDaysByYear(startDate, endDate);
+    const currentStatus = Array.isArray(status) ? status.at(-1)?.status : "UNKNOWN";
+
+    for (const [year, daysInYear] of Object.entries(daysByYear)) {
+      const success = await updateRemainingVacationDays(userId, daysInYear, currentStatus, year);
+      if (!success) {
+        return {
+          statusCode: 400,
+          body: JSON.stringify({
+            message: `Cannot create request: user does not have enough remaining vacation days for ${year}.`
+          })
+        };
+      }
+    }
 
     await notifyAdminsVacationSubmittedAll({
       id: newVacationRequestId,

--- a/src/functions/vacation-request/update-vacation-request/handler.ts
+++ b/src/functions/vacation-request/update-vacation-request/handler.ts
@@ -1,16 +1,12 @@
 import type { ValidatedEventAPIGatewayProxyEvent } from "@libs/api-gateway";
 import { middyfy } from "@libs/lambda";
-import type { Static } from "@sinclair/typebox";
 import { vacationRequestService } from "src/database/services";
-//import { notifyUserVacationStatusUpdatedAll } from "src/notifications/vacation-notifications";
-//import { CreateKeycloakApiService } from "src/database/services/keycloak-api-service";
+import { CreateKeycloakApiService } from "src/database/services/keycloak-api-service";
 import type { VacationRequest } from "src/generated/homeLambdasModels/model/vacationRequest";
+import { splitVacationDaysByYear, updateRemainingVacationDays } from "src/libs/vacation-utils";
+import { notifyUserVacationStatusUpdatedAll } from "src/notifications/vacation-notifications";
 import type vacationRequestSchema from "src/schema/vacationRequest";
 
-/**
- * Created Alias to prevent "Type instantiation is excessively deep and possibly infinite" warning on body
- */
-type VacationRequestBody = Static<typeof vacationRequestSchema>;
 /**
  * Lambda function to update a vacation request
  *
@@ -22,7 +18,7 @@ type VacationRequestBody = Static<typeof vacationRequestSchema>;
 
 // NOTE: Type mismatches between VacationRequestModel and VacationRequest (e.g. missing 'message', type differences).
 const updateVacationRequestHandler: ValidatedEventAPIGatewayProxyEvent<
-  VacationRequestBody
+  typeof vacationRequestSchema
 > = async (event) => {
   const { pathParameters, body } = event;
   const {
@@ -72,7 +68,7 @@ const updateVacationRequestHandler: ValidatedEventAPIGatewayProxyEvent<
       body: `Vacation request ${id} not found`
     };
   }
-  //const statusChanged = existingVacationRequest.status !== status;
+  const statusChanged = existingVacationRequest.status !== status;
 
   const vacationRequestUpdates = {
     id: existingVacationRequest.id,
@@ -89,23 +85,25 @@ const updateVacationRequestHandler: ValidatedEventAPIGatewayProxyEvent<
     updatedAt: updatedAt
   };
 
-  // TODO: Uncomment once Node.js is upgraded (required for notifications)
-  // const api = CreateKeycloakApiService();
-  // const userDetails = await api.findUser(userId);
+  const api = CreateKeycloakApiService();
+  const userDetails = await api.findUser(userId);
 
   try {
     const updatedVacationRequest =
       await vacationRequestService.updateVacationRequest(vacationRequestUpdates);
-
-    // TODO: Uncomment this once Node.js is upgraded (currently breaks due to resend dependency)
-    // if (statusChanged) {
-    //   await notifyUserVacationStatusUpdatedAll({
-    //     email: userDetails.email,
-    //     updatedStatus: status,
-    //   });
-    // }
-
-    // NOTE: Cast the updated request to VacationRequest so it matches the OpenAPI spec.
+    if (statusChanged) {
+      const currentStatus = Array.isArray(status) ? status.at(-1)?.status : "UNKNOWN";
+      await notifyUserVacationStatusUpdatedAll({
+        email: userDetails.email,
+        updatedStatus: currentStatus
+      });
+    }
+    if (status === "APPROVED") {
+      const daysByYear = splitVacationDaysByYear(startDate, endDate);
+      for (const [year, daysInYear] of Object.entries(daysByYear)) {
+        await updateRemainingVacationDays(userId, daysInYear, year);
+      }
+    }
     return {
       statusCode: 200,
       body: JSON.stringify(updatedVacationRequest as unknown as VacationRequest)

--- a/src/functions/vacation-request/update-vacation-request/handler.ts
+++ b/src/functions/vacation-request/update-vacation-request/handler.ts
@@ -83,22 +83,30 @@ const updateVacationRequestHandler: ValidatedEventAPIGatewayProxyEvent<
 
   const api = CreateKeycloakApiService();
   const userDetails = await api.findUser(userId);
+  const currentStatus = Array.isArray(status) ? status.at(-1)?.status : "UNKNOWN";
 
   try {
     const updatedVacationRequest =
       await vacationRequestService.updateVacationRequest(vacationRequestUpdates);
+    if (currentStatus === "APPROVED") {
+      const daysByYear = splitVacationDaysByYear(startDate, endDate);
+      for (const [year, daysInYear] of Object.entries(daysByYear)) {
+        const success = await updateRemainingVacationDays(userId, daysInYear, currentStatus, year);
+        if (!success) {
+          return {
+            statusCode: 400,
+            body: JSON.stringify({
+              message: `Cannot approve request: user does not have enough remaining vacation days for ${year}.`
+            })
+          };
+        }
+      }
+    }
     if (statusChanged) {
-      const currentStatus = Array.isArray(status) ? status.at(-1)?.status : "UNKNOWN";
       await notifyUserVacationStatusUpdatedAll({
         email: userDetails.email,
         updatedStatus: currentStatus
       });
-    }
-    if (status === "APPROVED") {
-      const daysByYear = splitVacationDaysByYear(startDate, endDate);
-      for (const [year, daysInYear] of Object.entries(daysByYear)) {
-        await updateRemainingVacationDays(userId, daysInYear, year);
-      }
     }
     return {
       statusCode: 200,

--- a/src/libs/vacation-utils.ts
+++ b/src/libs/vacation-utils.ts
@@ -50,23 +50,38 @@ export const splitVacationDaysByYear = (
 export const updateRemainingVacationDays = async (
   userId: string,
   daysToSubtract: number,
+  status: string,
   year: string
-) => {
+): Promise<boolean> => {
   const keycloakApiService = CreateKeycloakApiService();
-  const userDetails = await keycloakApiService.getUserAttributes(userId);
-  const unspentArr = userDetails.unspentVacationDaysByYear || [];
-  const index = unspentArr.findIndex((s) => s.startsWith(`${year}:`));
-  const currentValueStr = index >= 0 ? unspentArr[index].split(":")[1] : "0";
-  const currentValue = Number(currentValueStr);
+  const user = await keycloakApiService.getUserAttributes(userId);
+
+  user.attributes = user.attributes || [];
+
+  const unspentVacationDaysByYear = user.unspentVacationDaysByYear || [];
+
+  const currentEntry = unspentVacationDaysByYear.find((s) => s.startsWith(`${year}:`));
+  const currentValue = currentEntry ? Number(currentEntry.split(":")[1]) : 0;
+
+  if (currentValue < daysToSubtract) {
+    return false;
+  }
   const remainingDays = Math.max(currentValue - daysToSubtract, 0);
+  const formattedValue = `${year}:${String(remainingDays).padStart(3, "0")}`;
 
-  const updatedUnspent = [
-    ...unspentArr.filter((s) => !s.startsWith(`${year}:`)),
-    `${year}:${remainingDays.toString().padStart(3, "0")}`
-  ];
+  const updatedUnspent = [...unspentVacationDaysByYear];
+  const existingIndex = updatedUnspent.findIndex((s) => s.startsWith(`${year}:`));
 
-  await keycloakApiService.updateUserAttributes(userId, {
-    ...userDetails,
-    unspentVacationDaysByYear: updatedUnspent
-  });
+  if (existingIndex >= 0) {
+    updatedUnspent[existingIndex] = formattedValue;
+  } else {
+    updatedUnspent.push(formattedValue);
+  }
+
+  user.unspentVacationDaysByYear = [...new Set(updatedUnspent)];
+  user.attributes[`vacation_${year}_remaining`] = [String(remainingDays)];
+  if (status === "APPROVED") {
+    await keycloakApiService.updateUserAttributes(userId, user);
+  }
+  return true;
 };

--- a/src/libs/vacation-utils.ts
+++ b/src/libs/vacation-utils.ts
@@ -79,7 +79,6 @@ export const updateRemainingVacationDays = async (
   }
 
   user.unspentVacationDaysByYear = [...new Set(updatedUnspent)];
-  user.attributes[`vacation_${year}_remaining`] = [String(remainingDays)];
   if (status === "APPROVED") {
     await keycloakApiService.updateUserAttributes(userId, user);
   }

--- a/src/libs/vacation-utils.ts
+++ b/src/libs/vacation-utils.ts
@@ -12,6 +12,8 @@ import { CreateKeycloakApiService } from "src/database/services/keycloak-api-ser
  *
  * @returns An object where the keys are years and the values are the number of vacation days in that year.
  */
+
+// TODO: This requires updating to handle part time workers.
 export const splitVacationDaysByYear = (
   startDate: string,
   endDate: string

--- a/src/libs/vacation-utils.ts
+++ b/src/libs/vacation-utils.ts
@@ -1,0 +1,72 @@
+import { DateTime } from "luxon";
+import { CreateKeycloakApiService } from "src/database/services/keycloak-api-service";
+
+/**
+ * Splits a vacation period into the number of vacation days per year.
+ *
+ * Counts weekdays (Monday to Friday) by default, and optionally includes Saturdays
+ * if the vacation period is longer than 7 days.
+ *
+ * @param startDate - The start date of the vacation in ISO format (YYYY-MM-DD).
+ * @param endDate - The end date of the vacation in ISO format (YYYY-MM-DD).
+ *
+ * @returns An object where the keys are years and the values are the number of vacation days in that year.
+ */
+export const splitVacationDaysByYear = (
+  startDate: string,
+  endDate: string
+): Record<string, number> => {
+  const start = DateTime.fromISO(startDate);
+  const end = DateTime.fromISO(endDate);
+
+  const allDays = end.diff(start, "days").days + 1;
+  const includeSaturdays = allDays > 7;
+
+  const daysByYear: Record<string, number> = {};
+  let current = start;
+
+  while (current <= end) {
+    const weekday = current.weekday;
+    if (weekday <= 5 || (includeSaturdays && weekday === 6)) {
+      const year = current.year.toString();
+      daysByYear[year] = (daysByYear[year] || 0) + 1;
+    }
+
+    current = current.plus({ days: 1 });
+  }
+
+  return daysByYear;
+};
+
+/**
+ * Updates the remaining vacation days for a specific user and year.
+ *
+ * @param userId - The ID of the user whose vacation days are being updated.
+ * @param daysToSubtract - The number of vacation days to subtract from the user's remaining days.
+ * @param year - The year for which the vacation days are being updated.
+ *
+ * @returns A promise that resolves when the user's vacation days have been updated.
+ */
+export const updateRemainingVacationDays = async (
+  userId: string,
+  daysToSubtract: number,
+  year: string
+) => {
+  const api = CreateKeycloakApiService();
+  const userDetails = await api.getUserAttributes(userId);
+  const unspentArr = userDetails.unspentVacationDaysByYear || [];
+  const index = unspentArr.findIndex((s) => s.startsWith(`${year}:`));
+  const currentValueStr = index >= 0 ? unspentArr[index].split(":")[1] : "0";
+  const currentValue = Number(currentValueStr);
+  const remainingDays = Math.max(currentValue - daysToSubtract, 0);
+
+  const updatedUnspent = [
+    ...unspentArr.filter((s) => !s.startsWith(`${year}:`)),
+    `${year}:${remainingDays.toString().padStart(3, "0")}`
+  ];
+
+  await api.updateUserAttributes(userId, {
+    ...userDetails,
+    unspentVacationDaysByYear: updatedUnspent
+  });
+};

--- a/src/libs/vacation-utils.ts
+++ b/src/libs/vacation-utils.ts
@@ -52,8 +52,8 @@ export const updateRemainingVacationDays = async (
   daysToSubtract: number,
   year: string
 ) => {
-  const api = CreateKeycloakApiService();
-  const userDetails = await api.getUserAttributes(userId);
+  const keycloakApiService = CreateKeycloakApiService();
+  const userDetails = await keycloakApiService.getUserAttributes(userId);
   const unspentArr = userDetails.unspentVacationDaysByYear || [];
   const index = unspentArr.findIndex((s) => s.startsWith(`${year}:`));
   const currentValueStr = index >= 0 ? unspentArr[index].split(":")[1] : "0";
@@ -65,7 +65,7 @@ export const updateRemainingVacationDays = async (
     `${year}:${remainingDays.toString().padStart(3, "0")}`
   ];
 
-  await api.updateUserAttributes(userId, {
+  await keycloakApiService.updateUserAttributes(userId, {
     ...userDetails,
     unspentVacationDaysByYear: updatedUnspent
   });

--- a/src/libs/vacation-utils.ts
+++ b/src/libs/vacation-utils.ts
@@ -56,8 +56,6 @@ export const updateRemainingVacationDays = async (
   const keycloakApiService = CreateKeycloakApiService();
   const user = await keycloakApiService.getUserAttributes(userId);
 
-  user.attributes = user.attributes || [];
-
   const unspentVacationDaysByYear = user.unspentVacationDaysByYear || [];
 
   const currentEntry = unspentVacationDaysByYear.find((s) => s.startsWith(`${year}:`));


### PR DESCRIPTION
Added util file that splits vacation days so it consumes the correct years vacation days if the vacation happens around year shifts. Added function that consumes users unspent vacationdays based on the days on the approved request.

User gets an error if trying to create a new request if it exceeds the unspentDays amount, Same check is made for the approval of a request just in case so it does not update users unspentdays if the request consumes more days.