### PR TITLE
Bugfix 250 on call schedule throttling

### DIFF
--- a/src/database/services/oncall-schedule-api-service.ts
+++ b/src/database/services/oncall-schedule-api-service.ts
@@ -1,5 +1,13 @@
-import { DynamoDBDocumentClient, PutCommand, GetCommand, ScanCommand, DeleteCommand, UpdateCommand, QueryCommand } from "@aws-sdk/lib-dynamodb";
-import { PutCommandInput, GetCommandInput, ScanCommandInput, DeleteCommandInput, UpdateCommandInput, QueryCommandInput } from "@aws-sdk/lib-dynamodb";
+import {
+  BatchWriteCommand,
+  type DynamoDBDocumentClient,
+  PutCommand,
+  type PutCommandInput,
+  QueryCommand,
+  type QueryCommandInput,
+  UpdateCommand,
+  type UpdateCommandInput
+} from "@aws-sdk/lib-dynamodb";
 import type OnCallEntry from "../models/oncall";
 
 /**
@@ -15,19 +23,32 @@ class OnCallScheduleService {
   constructor(private readonly docClient: DynamoDBDocumentClient) {}
 
   /**
-   * Creates an OnCallSchedule entry
-   *
-   * @param entry OnCallSchedule entry
-   * @returns created entry
+   * Creates OnCallSchedule entiries in batches of 25
+   * @param entries OnCallSchedule entries
+   * @returns created entires
    */
-  public createOnCallFromJSON = async (entry: OnCallEntry): Promise<OnCallEntry> => {
-    const params: PutCommandInput = {
-      TableName: TABLE_NAME,
-      Item: entry
-    };
-    await this.docClient.send(new PutCommand(params));
-    return entry;
-  }
+  public createOnCallBatchFromJSON = async (entries: OnCallEntry[]): Promise<OnCallEntry[]> => {
+    const batches: OnCallEntry[][] = [];
+    const batchSize = 25;
+
+    for (let i = 0; i < entries.length; i += batchSize) {
+      batches.push(entries.slice(i, i + batchSize));
+    }
+
+    for (const batch of batches) {
+      const putRequests = batch.map((item) => ({ PutRequest: { Item: item } }));
+
+      const params = {
+        RequestItems: {
+          [TABLE_NAME]: putRequests
+        }
+      };
+
+      await this.docClient.send(new BatchWriteCommand(params));
+    }
+
+    return entries;
+  };
 
   /**
    * Lists all OnCallSchedule entries for a given year
@@ -47,8 +68,8 @@ class OnCallScheduleService {
       }
     };
     const result = await this.docClient.send(new QueryCommand(params));
-    return result.Items as OnCallEntry[] || [];
-  }
+    return (result.Items as OnCallEntry[]) || [];
+  };
 
   /**
    * Updates paid status for an OnCallSchedule entry
@@ -67,7 +88,7 @@ class OnCallScheduleService {
       }
     };
     await this.docClient.send(new UpdateCommand(params));
-  }
+  };
 
   /**
    * Upserts (creates or updates) an OnCallSchedule entry for a specific year and week
@@ -82,7 +103,7 @@ class OnCallScheduleService {
     };
     await this.docClient.send(new PutCommand(params));
     return entry;
-  }
+  };
 }
 
 export default OnCallScheduleService;

--- a/src/database/services/oncall-schedule-api-service.ts
+++ b/src/database/services/oncall-schedule-api-service.ts
@@ -24,7 +24,7 @@ class OnCallScheduleService {
 
   /**
    * Creates OnCallSchedule entiries in batches of 25
-   * @param entries OnCallSchedule entries
+   * @param entries Array of OnCallSchedule entries
    * @returns created entires
    */
   public createOnCallBatchFromJSON = async (entries: OnCallEntry[]): Promise<OnCallEntry[]> => {

--- a/src/functions/on-call/create-on-call-data-from-json/handler.ts
+++ b/src/functions/on-call/create-on-call-data-from-json/handler.ts
@@ -1,7 +1,7 @@
 import { middyfy } from "@libs/lambda";
 import type { OnCallImportEntry, OnCallImportError } from "src/database/models/oncall";
-import { isAdminUser } from "src/libs/auth-utils";
 import { onCallScheduleService } from "src/database/services";
+import { isAdminUser } from "src/libs/auth-utils";
 
 /**
  * Lambda method for importing on-call data from JSON
@@ -15,13 +15,15 @@ export const onCallImportFromJsonHandler = async (event) => {
       statusCode: 403,
       body: JSON.stringify({
         code: 403,
-        message: "Access denied. Admin privileges required.",
-      }),
+        message: "Access denied. Admin privileges required."
+      })
     };
   }
+
   const year = event.queryStringParameters?.year
     ? parseInt(event.queryStringParameters.year, 10)
     : undefined;
+
   if (!year || year < 2020 || year > new Date().getFullYear()) {
     return {
       statusCode: 400,
@@ -31,6 +33,7 @@ export const onCallImportFromJsonHandler = async (event) => {
       }
     };
   }
+
   let data: OnCallImportEntry[];
   try {
     data = typeof event.body === "string" ? JSON.parse(event.body) : event.body;
@@ -41,9 +44,10 @@ export const onCallImportFromJsonHandler = async (event) => {
       headers: {
         "Content-Type": "application/json"
       },
-      error: err.message,
+      error: err.message
     };
   }
+
   if (!Array.isArray(data)) {
     return {
       statusCode: 400,
@@ -54,33 +58,36 @@ export const onCallImportFromJsonHandler = async (event) => {
     };
   }
 
-  let imported = 0;
+  const validEntries = [];
   const errors: OnCallImportError[] = [];
   for (const entry of data) {
     if (
       typeof entry.Week !== "number" ||
       typeof entry.Person !== "string" ||
-      entry.Week < 1 || 
+      entry.Week < 1 ||
       entry.Week > 52
     ) {
       errors.push({ entry, error: "Invalid entry" });
       continue;
     }
+
+    validEntries.push({
+      Year: year,
+      Week: entry.Week,
+      Username: entry.Person,
+      Paid: false
+    });
+
     try {
-      await onCallScheduleService.createOnCallFromJSON({
-        Year: year,
-        Week: entry.Week,
-        Username: entry.Person,
-        Paid: false,
-      });
-      imported++;
+      await onCallScheduleService.createOnCallBatchFromJSON(validEntries);
     } catch (err) {
       errors.push({ entry, error: err });
     }
   }
+
   return {
     statusCode: errors.length ? 207 : 200,
-    body: JSON.stringify({ imported, errors }),
+    body: JSON.stringify({ validEntries, errors })
   };
 };
 


### PR DESCRIPTION
Replaced the createOnCallFromJSON function as createOnCallBatchFromJSON to fix throttling issue. Now it can push entries in batches of 25 to DynamoDb instead of one at a time.