### PR TITLE
feature-292-create-article-upload-image-not-working

### DIFF
--- a/src/functions/wiki-documentation/upload-file/handler.ts
+++ b/src/functions/wiki-documentation/upload-file/handler.ts
@@ -31,7 +31,7 @@ const uploadFileHandler: APIGatewayProxyHandler = async (event: APIGatewayProxyE
     };
 
   try {
-    const presignedUrl = await generatePreSignedUrl(path, contentType);
+    const presignedUrl = await generatePreSignedUrl(path, "put", contentType);
     return {
       statusCode: 200,
       body: JSON.stringify({ data: presignedUrl })


### PR DESCRIPTION
s3 service file has get | put with default of get, put should be defined as the action required for upload handler.