### PR TITLE
Update Slack avatar Lambda to omit image_original when missing and include reason

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16947,6 +16947,18 @@
         }
       }
     },
+    "node_modules/inquirer/node_modules/@types/node": {
+      "version": "25.0.9",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.0.9.tgz",
+      "integrity": "sha512-/rpCXHlCWeqClNBwUhDcusJxXYDjZTyE8v5oTO7WbL8eij2nKhUeU89/6xgjU7N4/Vh3He0BtyhJdQbDyhiXAw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "undici-types": "~7.16.0"
+      }
+    },
     "node_modules/inquirer/node_modules/iconv-lite": {
       "version": "0.7.0",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.0.tgz",
@@ -24190,6 +24202,15 @@
       "engines": {
         "node": ">=18.17"
       }
+    },
+    "node_modules/undici-types": {
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.16.0.tgz",
+      "integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true
     },
     "node_modules/uni-global": {
       "version": "1.0.0",

--- a/src/functions/slack/get-slack-user-avatar/handler.ts
+++ b/src/functions/slack/get-slack-user-avatar/handler.ts
@@ -1,11 +1,12 @@
 import type { APIGatewayProxyEvent, APIGatewayProxyHandler } from "aws-lambda";
+import { SlackAvatarResponse } from "src/generated/homeLambdasModels/model/slackAvatarResponse";
 import SlackUtilities from "src/meta-assistant/slack/slack-utils";
 
 /**
  * Lambda to receive user's slack avatar by email
  *
  * @param event event with query parameter email
- * @return A response object with statuscode and avatar URL
+ * @return SlackAvatarResponse object with image URL or reason for failure
  */
 const getSlackUserAvatarHandler: APIGatewayProxyHandler = async (event: APIGatewayProxyEvent) => {
   try {
@@ -20,21 +21,21 @@ const getSlackUserAvatarHandler: APIGatewayProxyHandler = async (event: APIGatew
 
     const email = decodeURIComponent(rawEmail.trim().toLowerCase());
     const slackUser = await SlackUtilities.getSlackUserByEmail(email);
+    const image_original = slackUser?.profile?.image_original ?? null;
+    let reason: SlackAvatarResponse.ReasonEnum;
 
-    if (!slackUser?.profile?.image_original) {
-      return {
-        statusCode: 204,
-        body: ""
-      };
+    if (!image_original) {
+      reason = slackUser
+        ? SlackAvatarResponse.ReasonEnum.NoAvatar
+        : SlackAvatarResponse.ReasonEnum.EmailMismatch;
     }
 
-    const response = {
-      image_original: slackUser.profile.image_original
-    };
+    const responseBody: SlackAvatarResponse = { imageOriginal: image_original };
+    if (reason) responseBody.reason = reason;
 
     return {
       statusCode: 200,
-      body: JSON.stringify(response)
+      body: JSON.stringify(responseBody)
     };
   } catch (error) {
     console.error("getSlackUserAvatarHandler failed", error);

--- a/src/functions/slack/get-slack-user-avatar/handler.ts
+++ b/src/functions/slack/get-slack-user-avatar/handler.ts
@@ -21,17 +21,16 @@ const getSlackUserAvatarHandler: APIGatewayProxyHandler = async (event: APIGatew
 
     const email = decodeURIComponent(rawEmail.trim().toLowerCase());
     const slackUser = await SlackUtilities.getSlackUserByEmail(email);
-    const image_original = slackUser?.profile?.image_original ?? null;
-    let reason: SlackAvatarResponse.ReasonEnum;
 
-    if (!image_original) {
-      reason = slackUser
+    const responseBody = new SlackAvatarResponse();
+
+    if (slackUser?.profile?.image_original) {
+      responseBody.imageOriginal = slackUser.profile.image_original;
+    } else {
+      responseBody.reason = slackUser
         ? SlackAvatarResponse.ReasonEnum.NoAvatar
         : SlackAvatarResponse.ReasonEnum.EmailMismatch;
     }
-
-    const responseBody: SlackAvatarResponse = { imageOriginal: image_original };
-    if (reason) responseBody.reason = reason;
 
     return {
       statusCode: 200,


### PR DESCRIPTION
Made changes to the get-slack-avatar handler so that the response will return image_original if there is a value, if not return a reason why.

Added enums that describe the reason the image_original is not present

Also generated the spec to have access to the type-safe OpenAPI class for the ReasonEnums so there is package updates in the process.