### PR TITLE
Bugfix 325 missing id on memo translation

### DIFF
--- a/serverless.ts
+++ b/serverless.ts
@@ -15,6 +15,7 @@ import onCallListDataHandler from "src/functions/on-call/list-on-call-data";
 import deleteQuestionnaireHandler from "src/functions/questionnaire/delete-questionnaire";
 import listQuestionnaireHandler from "src/functions/questionnaire/list-questionnaire";
 import updateQuestionnaireHandler from "src/functions/questionnaire/update-questionnaire";
+import addOptIn from "src/functions/severa/add-opt-in";
 import getContractedWorkWeekHandler from "src/functions/severa/get-filtered-workdays";
 import getWorkHoursHandler from "src/functions/severa/get-filtered-workhours";
 import getFlextimeHandler from "src/functions/severa/get-flextime-by-user";
@@ -49,7 +50,6 @@ import deleteSoftwareHandler from "@/functions/software-registry/delete-software
 import findSoftwareHandler from "@/functions/software-registry/find-software";
 import listSoftwareHandler from "@/functions/software-registry/list-software";
 import updateSoftwareHandler from "@/functions/software-registry/update-software";
-import addOptIn from "src/functions/severa/add-opt-in";
 
 const isLocal = process.env.STAGE === "local";
 const region = (env.AWS_DEFAULT_REGION as any) || "eu-north-1";
@@ -346,7 +346,7 @@ const serverlessConfiguration: AWS = {
                 { AttributeName: "fileId", KeyType: "HASH" },
                 { AttributeName: "language", KeyType: "RANGE" }
               ],
-              Projection: { ProjectionType: "KEYS_ONLY" },
+              Projection: { ProjectionType: "INCLUDE", NonKeyAttributes: ["id"] },
               ProvisionedThroughput: {
                 ReadCapacityUnits: 1,
                 WriteCapacityUnits: 1

--- a/src/functions/memo-management/drive-memos/translated-memos/create-translated-memo-pdf/handler.ts
+++ b/src/functions/memo-management/drive-memos/translated-memos/create-translated-memo-pdf/handler.ts
@@ -4,7 +4,7 @@ import type {
   APIGatewayProxyHandlerV2,
   APIGatewayProxyStructuredResultV2
 } from "aws-lambda";
-import type { MemoInput } from "src/database/models/memo-record";
+import type { MemoInput, MemoRecord } from "src/database/models/memo-record";
 import { memoService } from "src/database/services";
 import { middyfy } from "src/libs/lambda";
 
@@ -41,7 +41,7 @@ const createTranslatedMemoPdfHandler: APIGatewayProxyHandlerV2 = async (
     // Placeholder: default original language, detection can be added later
     const originalLanguage = "fi";
     const existingFi = await memoService.getByFileIdAndLanguage(fileId, originalLanguage);
-    let storedMemo: MemoInput;
+    let storedMemo: MemoRecord;
 
     if (existingFi) {
       storedMemo = existingFi;

--- a/src/functions/memo-management/drive-memos/translated-memos/create-translated-memo-pdf/handler.ts
+++ b/src/functions/memo-management/drive-memos/translated-memos/create-translated-memo-pdf/handler.ts
@@ -4,7 +4,7 @@ import type {
   APIGatewayProxyHandlerV2,
   APIGatewayProxyStructuredResultV2
 } from "aws-lambda";
-import type { MemoInput, MemoRecord } from "src/database/models/memo-record";
+import type { MemoRecord } from "src/database/models/memo-record";
 import { memoService } from "src/database/services";
 import { middyfy } from "src/libs/lambda";
 


### PR DESCRIPTION
When i was testing the createTranslatedPdf handler locally it would give the id of the memoRecord when initially creating the record and also when the GSI was queried, but on the deployed handler it would not return the id. 

Changed the serverless dynamodb config to return the memoRecord's id in the GSI query result. Also used the memoRecord type on the handler instead of memoInput to enforce the id is included.