### PR TITLE
Retry bugfix of missing id on memo translation

### DIFF
--- a/src/database/services/translated-memo-api-service.ts
+++ b/src/database/services/translated-memo-api-service.ts
@@ -76,12 +76,12 @@ class TranslatedMemoService {
    * @param fileId - The Google Drive file ID associated with the memo.
    * @param language - The language of the memo.
    *
-   * @returns The `MemoRecord` if found, or `null` if no matching memo exists.
+   * @returns The `item.id` if found, or `null` if no matching memo exists.
    */
   public getByFileIdAndLanguage = async (
     fileId: string,
     language: string
-  ): Promise<MemoRecord | null> => {
+  ): Promise<string | null> => {
     const result = await this.docClient.send(
       new QueryCommand({
         TableName: TABLE_NAME,
@@ -97,8 +97,8 @@ class TranslatedMemoService {
         }
       })
     );
-
-    return (result.Items?.[0] as MemoRecord) || null;
+    const item = result.Items?.[0];
+    return item?.id || null;
   };
 }
 

--- a/src/database/services/translated-memo-api-service.ts
+++ b/src/database/services/translated-memo-api-service.ts
@@ -98,7 +98,7 @@ class TranslatedMemoService {
       })
     );
     const item = result.Items?.[0];
-    return item?.id || null;
+    return item?.id ?? null;
   };
 }
 

--- a/src/functions/memo-management/drive-memos/translated-memos/create-translated-memo-pdf/handler.ts
+++ b/src/functions/memo-management/drive-memos/translated-memos/create-translated-memo-pdf/handler.ts
@@ -4,7 +4,7 @@ import type {
   APIGatewayProxyHandlerV2,
   APIGatewayProxyStructuredResultV2
 } from "aws-lambda";
-import type { MemoInput } from "src/database/models/memo-record";
+import type { MemoRecord } from "src/database/models/memo-record";
 import { memoService } from "src/database/services";
 import { middyfy } from "src/libs/lambda";
 
@@ -40,11 +40,13 @@ const createTranslatedMemoPdfHandler: APIGatewayProxyHandlerV2 = async (
 
     // Placeholder: default original language, detection can be added later
     const originalLanguage = "fi";
-    const existingFi = await memoService.getByFileIdAndLanguage(fileId, originalLanguage);
-    let storedMemo: MemoInput;
+    const existingFiId = await memoService.getByFileIdAndLanguage(fileId, originalLanguage);
+    let memoId: string | null;
+    let message: string;
 
-    if (existingFi) {
-      storedMemo = existingFi;
+    if (existingFiId) {
+      memoId = existingFiId;
+      message = "Translated memo record already exists";
     } else {
       const pdfFile = await getFileContentPdf(file);
       if (!pdfFile?.content) {
@@ -53,7 +55,7 @@ const createTranslatedMemoPdfHandler: APIGatewayProxyHandlerV2 = async (
 
       const originalBase64 = pdfFile.content.toString("base64");
 
-      storedMemo = await memoService.storeMemoRecord(
+      const storedMemo: MemoRecord = await memoService.storeMemoRecord(
         {
           fileId: file.id,
           fileName: file.name,
@@ -62,6 +64,8 @@ const createTranslatedMemoPdfHandler: APIGatewayProxyHandlerV2 = async (
         },
         true
       );
+      memoId = storedMemo.id;
+      message = "Translated memo record created successfully";
     }
     // TODO: Translate PDF and store translated version
     // Uncomment and implement proper logic when translation service is ready
@@ -86,10 +90,8 @@ const createTranslatedMemoPdfHandler: APIGatewayProxyHandlerV2 = async (
     return {
       statusCode: 200,
       body: JSON.stringify({
-        message: existingFi
-          ? "Translated memo record already exists"
-          : "Translated memo record created successfully",
-        id: storedMemo.id
+        message,
+        id: memoId
       })
     };
   } catch (error) {


### PR DESCRIPTION
Translated-memo-api-service now only returns the id of the existing record -> handler only returns the id of the memoRecord on creation or fetching the existing record.

Returning of the id works when tested on postman and it should now also work on the UI, Please test the memos translation function after this PR is merged.

feature-branch to test on: https://github.com/Metatavu/metatavu-home/tree/feature-350-merge-forked-management-memos-branch