### PR TITLE
Add response headers for error handling in uploadFileHandler

### DIFF
--- a/src/functions/wiki-documentation/upload-file/handler.ts
+++ b/src/functions/wiki-documentation/upload-file/handler.ts
@@ -58,6 +58,7 @@ const uploadFileHandler: APIGatewayProxyHandler = async (event: APIGatewayProxyE
     console.error("JSON parsing failed:", error);
     return {
       statusCode: 400,
+      headers: responseHeaders,
       body: JSON.stringify({
         code: 400,
         message: "Invalid JSON body."
@@ -69,6 +70,7 @@ const uploadFileHandler: APIGatewayProxyHandler = async (event: APIGatewayProxyE
     console.warn("Missing path");
     return {
       statusCode: 400,
+      headers: responseHeaders,
       body: JSON.stringify({
         code: 400,
         message: "Invalid request body."
@@ -81,6 +83,7 @@ const uploadFileHandler: APIGatewayProxyHandler = async (event: APIGatewayProxyE
   if (!isImage && !isPdf) {
     return {
       statusCode: 400,
+      headers: responseHeaders,
       body: JSON.stringify({
         code: 400,
         message: "Invalid file type."
@@ -91,6 +94,7 @@ const uploadFileHandler: APIGatewayProxyHandler = async (event: APIGatewayProxyE
   if (isPdf && !isAdminUser(event)) {
     return {
       statusCode: 403,
+      headers: responseHeaders,
       body: JSON.stringify({
         code: 403,
         message: "Only admin can upload PDF files."
@@ -101,6 +105,7 @@ const uploadFileHandler: APIGatewayProxyHandler = async (event: APIGatewayProxyE
   if (!HOME_BUCKET_NAME || !HOME_BUCKET_REGION) {
     return {
       statusCode: 500,
+      headers: responseHeaders,
       body: JSON.stringify({
         code: 500,
         message: "Invalid lambda environment variables"


### PR DESCRIPTION
Added missing headers on error handling, hope this makes the home lambda work now


now i'm getting this error

Access to fetch at 'https://sck28bg5v9.execute-api.eu-north-1.amazonaws.com/articles/import-document' from origin 'http://localhost:5173' has been blocked by CORS policy: No 'Access-Control-Allow-Origin' header is present on the requested resource.Understand this error
runtime.ts:182  POST https://sck28bg5v9.execute-api.eu-north-1.amazonaws.com/articles/import-document net::ERR_FAILED 404 (Not Found)
(anonymous) @ runtime.ts:182
(anonymous) @ runtime.ts:118
await in (anonymous)
(anonymous) @ ArticleApi.ts:324
await in (anonymous)
(anonymous) @ ArticleApi.ts:340
(anonymous) @ s3-file-utils.ts:92
await in (anonymous)
(anonymous) @ create-article-form.tsx:228
callCallback2 @ chunk-V5LT2MCF.js?v=f1c311e9:3674
invokeGuardedCallbackDev @ chunk-V5LT2MCF.js?v=f1c311e9:3699
invokeGuardedCallback @ chunk-V5LT2MCF.js?v=f1c311e9:3733
invokeGuardedCallbackAndCatchFirstError @ chunk-V5LT2MCF.js?v=f1c311e9:3736
executeDispatch @ chunk-V5LT2MCF.js?v=f1c311e9:7016
processDispatchQueueItemsInOrder @ chunk-V5LT2MCF.js?v=f1c311e9:7036
processDispatchQueue @ chunk-V5LT2MCF.js?v=f1c311e9:7045
dispatchEventsForPlugins @ chunk-V5LT2MCF.js?v=f1c311e9:7053
(anonymous) @ chunk-V5LT2MCF.js?v=f1c311e9:7177
batchedUpdates$1 @ chunk-V5LT2MCF.js?v=f1c311e9:18941
batchedUpdates @ chunk-V5LT2MCF.js?v=f1c311e9:3579
dispatchEventForPluginEventSystem @ chunk-V5LT2MCF.js?v=f1c311e9:7176
dispatchEventWithEnableCapturePhaseSelectiveHydrationWithoutDiscreteEventReplay @ chunk-V5LT2MCF.js?v=f1c311e9:5478
dispatchEvent @ chunk-V5LT2MCF.js?v=f1c311e9:5472
dispatchDiscreteEvent @ chunk-V5LT2MCF.js?v=f1c311e9:5449Understand this error
installHook.js:1 Error importing playbook: FetchError: The request failed and the interceptors did not return an alternative response
    at ArticleApi.fetchApi (runtime.ts:197:23)
    at async ArticleApi.request (runtime.ts:118:26)
    at async ArticleApi.importDocumentRaw (ArticleApi.ts:324:26)
    at async ArticleApi.importDocument (ArticleApi.ts:340:26)
    at async importPlaybook (s3-file-utils.ts:92:18)
    at async handleImport (create-article-form.tsx:228:31)Caused by: TypeError: Failed to fetch
    at ArticleApi.fetchApi (runtime.ts:182:62)
    at ArticleApi.request (runtime.ts:118:37)
    at async ArticleApi.importDocumentRaw (ArticleApi.ts:324:26)
    at async ArticleApi.importDocument (ArticleApi.ts:340:26)
    at async importPlaybook (s3-file-utils.ts:92:18)
    at async handleImport (create-article-form.tsx:228:31)