### PR TITLE
Fix build errors

### DIFF
--- a/src/functions/keycloak/get-user-roles/handler.ts
+++ b/src/functions/keycloak/get-user-roles/handler.ts
@@ -1,6 +1,6 @@
 import type { APIGatewayProxyEvent, APIGatewayProxyHandler } from "aws-lambda";
-import { CreateKeycloakApiService } from "src/database/services/keycloak-api-service";
 import { middyfy } from "src/libs/lambda";
+import { CreateKeycloakApiService } from "src/services/keycloak-api-service";
 
 const getUserRolesHandler: APIGatewayProxyHandler = async (event: APIGatewayProxyEvent) => {
   try {

--- a/src/functions/keycloak/update-user-roles/handler.ts
+++ b/src/functions/keycloak/update-user-roles/handler.ts
@@ -1,6 +1,6 @@
 import type { APIGatewayProxyEvent, APIGatewayProxyHandler } from "aws-lambda";
-import { CreateKeycloakApiService } from "src/database/services/keycloak-api-service";
 import { middyfy } from "src/libs/lambda";
+import { CreateKeycloakApiService } from "src/services/keycloak-api-service";
 
 const updateUserRolesHandler: APIGatewayProxyHandler = async (event: APIGatewayProxyEvent) => {
   try {


### PR DESCRIPTION
Google cloud build kept failing because of wrong imports that now are fixed